### PR TITLE
Fix a couple of additional warnings.

### DIFF
--- a/parser.hh
+++ b/parser.hh
@@ -438,11 +438,11 @@ public:
 	/**
 	 * Iterator to the start of the input range.
 	 */
-	Input::iterator begin() const { return start.it; };
+	Input::iterator begin() const { return start.it; }
 	/**
 	 * Iterator to the end of the input range.
 	 */
-	Input::iterator end() const { return finish.it; };
+	Input::iterator end() const { return finish.it; }
 };
 
 


### PR DESCRIPTION
Clang's -Weverything complains about semicolons after method definitions.
